### PR TITLE
Fix for KB3185319 issue on Windows OSes with IE11

### DIFF
--- a/pvr_manager.cmd
+++ b/pvr_manager.cmd
@@ -4,4 +4,4 @@ set GIP_INST=%~dp0
 if #%GIP_INST:~-1%# == #\# set GIP_INST=%GIP_INST:~0,-1%
 start "PVR Manager Service" /min /b cmd /k "%GIP_INST%\get_iplayer.cgi.cmd"
 ping 127.0.0.1 -n 5 -w 1000 > NUL
-"%GIP_INST%\pvr_manager.url"
+start http://localhost:1935

--- a/pvr_manager.url
+++ b/pvr_manager.url
@@ -1,2 +1,0 @@
-[InternetShortcut]
-URL=http://localhost:1935


### PR DESCRIPTION
 Windows Update KB3185319 for IE11 that was pushed to MS supported 
OSes on Tue 13/09/2016 causes the slight annoyance described in 

https://squarepenguin.co.uk/forums/thread-1051-post-4731.html

and documented in 

https://github.com/get-iplayer/get_iplayer/issues/303

 OSes affected are Win7, Win8.1 and Win10. 
WinVista also got a KB3185319 update but remains 
unaffected, because there the (maximum) version of IE is 9. 

 Instead of launching a .url file from within the batch file, 
we can dispense altogether with it and instead launch 
the system's default browser to URL=http://localhost:1935 
via the native START command...
Tested to work OK on a Win7 SP1 64bit laptop, with Firefox 
as the default...
